### PR TITLE
Unified API for @use Statecharts AND Automatic action creation

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,6 +1,7 @@
 import useMachine, {
   ConfigurableMachineDefinition,
   InterpreterUsable,
+  Statechart,
 } from './usables/use-machine';
 
 import {
@@ -75,4 +76,4 @@ function interpreterFor<
   >;
 }
 
-export { useMachine, matchesState, interpreterFor };
+export { useMachine, matchesState, interpreterFor, Statechart };

--- a/addon/usables/use-machine.ts
+++ b/addon/usables/use-machine.ts
@@ -26,14 +26,74 @@ const ERROR_CHART_MISSING = `A statechart was not passed`;
 
 type Args<Context, Schema extends StateSchema, Event extends EventObject> = {
   positional?: [
-    {
-      chart: MachineConfig<Context, Schema, Event>;
-      config?: Partial<MachineOptions<Context, Event>>;
-      context?: Context;
-      initialState?: State<Context, Event>;
-      onTransition?: StateListener<Context, Event, Schema, Typestate<Context>>;
-    }
+    any,
+    MachineConfig<Context, Schema, Event>,
+    Partial<MachineOptions<Context, Event>> &
+      StateListener<Context, Event, Schema, Typestate<Context>>
   ];
+};
+
+const gatherActions = function (object, actionsArray) {
+  for (let k in object) {
+    if (['entry', 'exit', 'actions'].includes(k)) {
+      if (Array.isArray(object[k])) {
+        actionsArray = actionsArray.concat(object[k]);
+      } else if (typeof object[k] === 'string') {
+        actionsArray.push(object[k]);
+      }
+    } else if (typeof object[k] === 'object' && object[k] !== null) {
+      actionsArray = gatherActions(object[k], actionsArray);
+    }
+  }
+  return actionsArray;
+};
+
+const gatherGuards = function (object, acc) {
+  for (let k in object) {
+    if (k === 'cond') {
+      if (typeof object[k] === 'object' && object[k] !== null && object[k].hasOwnProperty('type')) {
+        acc.push(object[k].type);
+      } else {
+        acc.push(object[k]);
+      }
+      acc.push(object[k]);
+    } else if (typeof object[k] === 'object' && object[k] !== null) {
+      acc = gatherGuards(object[k], acc);
+    }
+  }
+  return acc;
+};
+
+const gatherActivities = function (object, acc) {
+  for (let k in object) {
+    if (k === 'activities') {
+      acc = acc.concat(object[k]);
+    } else if (typeof object[k] === 'object' && object[k] !== null) {
+      acc = gatherActivities(object[k], acc);
+    }
+  }
+  return acc;
+};
+
+const gatherDelays = function (object, acc) {
+  for (let k in object) {
+    if (k === 'after') {
+      if (typeof object[k] === 'object' && object[k] !== null) {
+        acc = acc.concat(Object.keys(object[k]));
+      } else if (Array.isArray(object[k])) {
+        object[k].forEach((el) => {
+          for (let key in el) {
+            if (key === 'delay') {
+              acc.push(el[key]);
+            }
+          }
+        });
+      }
+    } else if (typeof object[k] === 'object' && object[k] !== null) {
+      acc = gatherDelays(object[k], acc);
+    }
+  }
+  return acc;
 };
 
 type SendArgs<Context, Schema extends StateSchema, Event extends EventObject> = Parameters<
@@ -43,9 +103,15 @@ type SendArgs<Context, Schema extends StateSchema, Event extends EventObject> = 
 /**
  *
   @use statechart = new Statechart(() => [{
-    chart: chart,
-    config: {},
-    context: {},
+    owner: this,
+    chart,
+    // below are optional:
+    context,
+    activities,
+    guards,
+    delays,
+    onTransition,
+    update
   }])
  */
 export class Statechart<
@@ -64,14 +130,7 @@ export class Statechart<
   get value(): {
     state?: State<Context, Event>;
     send: Statechart<Context, Schema, Event>['send'];
-    // withContext: Statechart<Context, Schema, Event>['withContext'];
-    // withConfig: Statechart<Context, Schema, Event>['withConfig'];
-    // onTransition: Statechart<Context, Schema, Event>['onTransition'];
   } {
-    // if (!this[INTERPRETER]) {
-    //   this._setupMachine();
-    // }
-
     return {
       // For TypeScript, this is tricky because this is what is accessible at the call site
       // but typescript thinks the context is the class instance.
@@ -79,54 +138,7 @@ export class Statechart<
       // To remedy, each property has to also exist on the class body under the same name
       state: this.state,
       send: this.send,
-
-      /**
-       * One Time methods
-       * Currently disabled due to issues with the use/resource transform not allowing
-       * the builder pattern
-       *
-       * If the transform is fixed, we can remove the protected visibility modifier
-       * and uncomment out these three lines in a back-compat way for existing users
-       */
-      // withContext: this.withContext,
-      // withConfig: this.withConfig,
-      // onTransition: this.onTransition,
     };
-  }
-
-  @action
-  protected withContext(context?: Context) {
-    assert(ERROR_CANT_RECONFIGURE, !this[INTERPRETER]);
-
-    if (context) {
-      this[MACHINE] = this[MACHINE].withContext(context);
-    }
-
-    return this;
-  }
-
-  @action
-  protected withConfig(config?: Partial<MachineOptions<Context, Event>>) {
-    assert(ERROR_CANT_RECONFIGURE, !this[INTERPRETER]);
-
-    if (config) {
-      this[MACHINE] = this[MACHINE].withConfig(config);
-    }
-
-    return this;
-  }
-
-  @action
-  protected onTransition(fn?: StateListener<Context, Event, Schema, Typestate<Context>>) {
-    if (!this[INTERPRETER]) {
-      this._setupMachine();
-    }
-
-    if (fn) {
-      this[INTERPRETER].onTransition(fn);
-    }
-
-    return this;
   }
 
   /**
@@ -139,7 +151,12 @@ export class Statechart<
   }
 
   @action
-  private _setupMachine() {}
+  update() {
+    let { update } = this.args.positional[0];
+    if (update) {
+      update(this.send, this.state.context);
+    }
+  }
 
   /**
    * Lifecycle methods on Resource
@@ -147,39 +164,65 @@ export class Statechart<
    */
   @action
   protected setup() {
-    console.log('this.setup');
-    let { chart, context, config, owner } = this.args.positional?.[0];
+    let {
+      context,
+      activities,
+      actions,
+      guards,
+      delays,
+      onTransition,
+      owner,
+      chart,
+    } = this.args.positional?.[0];
 
     assert(ERROR_CHART_MISSING, chart);
 
-    let gatherActions = function (object, actionsArray) {
-      for (let k in object) {
-        if (['entry', 'exit', 'actions'].includes(k)) {
-          if (Array.isArray(object[k])) {
-            actionsArray = actionsArray.concat(object[k]);
-          } else if (typeof object[k] === 'string') {
-            actionsArray.push(object[k]);
-          }
-        } else if (typeof object[k] === 'object' && object[k] !== null) {
-          actionsArray = gatherActions(object[k], actionsArray);
-        }
-      }
-      return actionsArray;
-    };
-
-    let allActions: Array<string> = gatherActions(chart, []);
+    // This all could likely be refactored into one function but it could get a dice
+    let allActions = gatherActions(chart, []);
     let actionsConfig = allActions.reduce((acc, actionName) => {
-      if (owner[actionName] === undefined) throw Error(`Must implement ${actionName}.`);
+      assert(`Must implement function for the action: ${actionName}`, owner[actionName]);
       acc[actionName] = owner[actionName];
       return acc;
     }, {});
 
-    let actions = config?.actions || {};
-    actions = { ...actionsConfig, ...actions };
-    config = config || {};
-    config = { ...config, ...{ actions: actions } };
+    let allGuards: Array<string> = gatherGuards(chart, []);
+    let guardsConfig = allGuards.reduce((acc, guardName) => {
+      assert(`Must implement function for the guard: ${guardName}`, owner[guardName]);
+      acc[guardName] = owner[guardName];
+      return acc;
+    }, {});
 
-    this[MACHINE] = Machine(chart).withContext(context).withConfig(config);
+    let allActivities: Array<string> = gatherActivities(chart, []);
+    let activitiesConfig = allActivities.reduce((acc, activityName) => {
+      assert(`Must implement function for the activity: ${activityName}`, owner[activityName]);
+      acc[activityName] = owner[activityName];
+      return acc;
+    }, {});
+
+    let allDelays: Array<string> = gatherDelays(chart, []);
+    let delayConfig = allDelays.reduce((acc, delayName) => {
+      assert(`Must implement function for the delay: ${delayName}`, owner[delayName]);
+      acc[delayName] = owner[delayName];
+      return acc;
+    }, {});
+
+    // Combine into one config object -- this also could be done better
+    actions = actions || {};
+    actions = { ...actionsConfig, ...actions };
+    guards = guards || {};
+    guards = { ...guardsConfig, ...guards };
+    context = context || {};
+    activities = activities || {};
+    activities = { ...activitiesConfig, ...activities };
+    delays = delays || {};
+    delays = { ...delayConfig, ...delays };
+
+    this[MACHINE] = Machine(chart).withContext(context).withConfig({
+      guards,
+      actions,
+      activities,
+      delays,
+    });
 
     this[INTERPRETER] = interpret(this[MACHINE], {
       devTools: DEBUG,
@@ -197,7 +240,9 @@ export class Statechart<
       this.state = state;
     });
 
-    this.onTransition(config?.onTransition);
+    if (onTransition) {
+      this[INTERPRETER].onTransition(onTransition);
+    }
 
     this[INTERPRETER].start();
   }


### PR DESCRIPTION
This is WIP as the tests and types are off, but it works and the first test in the use-machine-test.js works.

1. It makes the public API for creating a statechart with @use to be:

  @use statechart = new Statechart(() => [{
    chart: chart,
    config: {}, // optional
    context: {}, //optional
  }])

2. It defaults the actions -- if an action is specified, it will automatically call a function of the same name in the object that's using the statechart. No more extraneous actions object!